### PR TITLE
Shrink image 3.5x and make script more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-FROM debian:jessie
+FROM gliderlabs/alpine:3.3
 
-# install deps
-RUN apt-get update && apt-get install -y apt-transport-https python python-pip unzip
+RUN apk --no-cache add bash docker python py-pip \
+    && mkdir ~/.aws \
+    && pip install --upgrade pip \
+    && pip install awscli
 
-# install docker
-RUN echo 'deb https://apt.dockerproject.org/repo debian-jessie main' > /etc/apt/sources.list.d/docker.list
-RUN apt-get update && apt-get install -y --force-yes docker-engine
+ADD aws_docker_creds.sh /
 
-ENV PATH /root/.local/lib/aws/bin/:$PATH
-
-RUN mkdir -p ~/.aws
-
-RUN pip install awscli
-
-ADD aws_docker_creds.sh . 
-
-ENTRYPOINT ["./aws_docker_creds.sh"]
+ENTRYPOINT ["/aws_docker_creds.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM gliderlabs/alpine:3.3
 
-RUN apk --no-cache add bash docker python py-pip \
+RUN apk --no-cache add bash docker
+
+# purposely split this up so layers can download in parallel
+RUN apk --no-cache add python py-pip \
     && mkdir ~/.aws \
     && pip install --upgrade pip \
     && pip install awscli

--- a/aws_docker_creds.sh
+++ b/aws_docker_creds.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set -e
+
+echo 'AWS ECR dockercfg generator'
+
+: "${AWS_REGION:?Need to set AWS_REGION}"
+: "${AWS_ACCESS_KEY_ID:?Need to set AWS_ACCESS_KEY_ID}"
+: "${AWS_SECRET_ACCESS_KEY:?Need to set AWS_SECRET_ACCESS_KEY}"
+
 cat << EOF > ~/.aws/config
 [default]
 region = $AWS_REGION


### PR DESCRIPTION
The debian-based build is 488MB when I download it, this build is 138MB. Since codeship doesn't cache any docker images for you, this difference cuts out ~1.5 minutes from my codeship build times.

Also fixes issues where script wouldn't exit if a step failed and where there was no output if environment variables weren't found, which made it hard for me to get working on codeship (the combination of an error in the codeship docs using the wrong key for the encrypted env vars, plus the fact that this script gave no indication the env vars were missing made things confusing).
