### PR TITLE
Credential Caching

### DIFF
--- a/aws_docker_creds.sh
+++ b/aws_docker_creds.sh
@@ -34,10 +34,15 @@ fi
 
 # fetching aws docker login
 echo "Logging into AWS ECR"
-$(aws ecr get-login)
+if [ -f /opt/docker/config.json ]; then
+    mkdir -p ~/.docker
+    cp /opt/docker/config.json ~/.docker/config.json
+else
+    $(aws ecr get-login)
+    cp ~/.docker/config.json /opt/docker/config.json
+fi
 
 # writing aws docker creds to desired path
 echo "Writing Docker creds to $1"
 chmod 544 ~/.docker/config.json
 cp ~/.docker/config.json $1
-

--- a/aws_docker_creds.sh
+++ b/aws_docker_creds.sh
@@ -33,11 +33,12 @@ if [[ -n $AWS_STS_ROLE || -n $AWS_STS_ACCOUNT ]]; then
 fi
 
 # fetching aws docker login
-echo "Logging into AWS ECR"
 if [ -f /opt/docker/config.json ]; then
+    echo "Setting previous AWS ECR login"
     mkdir -p ~/.docker
     cp /opt/docker/config.json ~/.docker/config.json
 else
+    echo "Logging into AWS ECR"
     $(aws ecr get-login)
     cp ~/.docker/config.json /opt/docker/config.json
 fi


### PR DESCRIPTION
I made a small change to allow caching by sharing a volume to /opt/docker/. This allows using the same generator service without having to generate credentials each time.
